### PR TITLE
Don't read from uninitialized memory

### DIFF
--- a/TE2PE.c
+++ b/TE2PE.c
@@ -204,7 +204,7 @@ UINT8 convert(UINT8* te, UINTN teSize, UINT8** peOut, UINTN* peOutSize)
     EFI_IMAGE_SECTION_HEADER* sectionHeader;
 
     // Check arguments for sanity
-    if (!te || teSize <= sizeof(EFI_IMAGE_TE_HEADER) || !peOut || !(*peOut) || !peOutSize) {
+    if (!te || teSize <= sizeof(EFI_IMAGE_TE_HEADER) || !peOut || || !peOutSize) {
         printf("convert: called with invalid parameter\n");
         return ERR_INVALID_PARAMETER;
     }


### PR DESCRIPTION
`*peOut` gets overwritten at the end of the function anyway.