### PR TITLE
Copy OptionalHeader.ImageBase directly from TE header

### DIFF
--- a/TE2PE.c
+++ b/TE2PE.c
@@ -305,7 +305,7 @@ UINT8 convert(UINT8* te, UINTN teSize, UINT8** peOut, UINTN* peOutSize)
             PeHeader.Header32.OptionalHeader.Magic = EFI_IMAGE_PE_OPTIONAL_HDR32_MAGIC;
             PeHeader.Header32.OptionalHeader.AddressOfEntryPoint = teHeader->AddressOfEntryPoint;
             PeHeader.Header32.OptionalHeader.BaseOfCode = teHeader->BaseOfCode;
-            PeHeader.Header32.OptionalHeader.ImageBase = (UINT32)(teHeader->ImageBase - teHeader->StrippedSize + sizeof(EFI_IMAGE_TE_HEADER));
+            PeHeader.Header32.OptionalHeader.ImageBase = (UINT32)teHeader->ImageBase;
             PeHeader.Header32.OptionalHeader.SectionAlignment = 0x10;
             PeHeader.Header32.OptionalHeader.FileAlignment = 0x10;
             PeHeader.Header32.OptionalHeader.SizeOfImage = peSize;
@@ -330,7 +330,7 @@ UINT8 convert(UINT8* te, UINTN teSize, UINT8** peOut, UINTN* peOutSize)
             PeHeader.Header64.OptionalHeader.Magic = EFI_IMAGE_PE_OPTIONAL_HDR64_MAGIC;
             PeHeader.Header64.OptionalHeader.AddressOfEntryPoint = teHeader->AddressOfEntryPoint;
             PeHeader.Header64.OptionalHeader.BaseOfCode = teHeader->BaseOfCode;
-            PeHeader.Header64.OptionalHeader.ImageBase = (UINT32)(teHeader->ImageBase - teHeader->StrippedSize + sizeof(EFI_IMAGE_TE_HEADER));
+            PeHeader.Header64.OptionalHeader.ImageBase = (UINT32)teHeader->ImageBase;
             PeHeader.Header64.OptionalHeader.SectionAlignment = 0x10;
             PeHeader.Header64.OptionalHeader.FileAlignment = 0x10;
             PeHeader.Header64.OptionalHeader.SizeOfImage = peSize;


### PR DESCRIPTION
As per the TE image format description in the UEFI PI spec [1], the image base is "as specified in the original image's optional header". The incorrect value was causing absolute addresses to break due to the incorrect load address of the image.

[1] https://uefi.org/specs/PI/1.8/V1_TE_Image.html